### PR TITLE
Add stub implementation of EnumSystemFirmwareTables

### DIFF
--- a/dlls/api-ms-win-core-sysinfo-l1-2-0/api-ms-win-core-sysinfo-l1-2-0.spec
+++ b/dlls/api-ms-win-core-sysinfo-l1-2-0/api-ms-win-core-sysinfo-l1-2-0.spec
@@ -1,4 +1,4 @@
-@ stub EnumSystemFirmwareTables
+@ stdcall EnumSystemFirmwareTables(long ptr long) kernel32.EnumSystemFirmwareTables
 @ stdcall GetComputerNameExA(long ptr ptr) kernel32.GetComputerNameExA
 @ stdcall GetComputerNameExW(long ptr ptr) kernel32.GetComputerNameExW
 @ stdcall GetLocalTime(ptr) kernel32.GetLocalTime

--- a/dlls/api-ms-win-core-sysinfo-l1-2-1/api-ms-win-core-sysinfo-l1-2-1.spec
+++ b/dlls/api-ms-win-core-sysinfo-l1-2-1/api-ms-win-core-sysinfo-l1-2-1.spec
@@ -1,5 +1,5 @@
 @ stub DnsHostnameToComputerNameExW
-@ stub EnumSystemFirmwareTables
+@ stdcall EnumSystemFirmwareTables(long ptr long) kernel32.EnumSystemFirmwareTables
 @ stdcall GetComputerNameExA(long ptr ptr) kernel32.GetComputerNameExA
 @ stdcall GetComputerNameExW(long ptr ptr) kernel32.GetComputerNameExW
 @ stdcall GetLocalTime(ptr) kernel32.GetLocalTime

--- a/dlls/kernel32/cpu.c
+++ b/dlls/kernel32/cpu.c
@@ -374,27 +374,6 @@ UINT WINAPI GetSystemFirmwareTable(DWORD provider, DWORD id, void *buffer, DWORD
  */
 UINT WINAPI EnumSystemFirmwareTables(DWORD provider, void *buffer, DWORD size)
 {
-    ULONG buffer_size = FIELD_OFFSET(SYSTEM_FIRMWARE_TABLE_INFORMATION, TableBuffer) + size;
-    SYSTEM_FIRMWARE_TABLE_INFORMATION *sfti = HeapAlloc(GetProcessHeap(), 0, buffer_size);
-    NTSTATUS status;
-
-    TRACE("(0x%08x, %p, %d)\n", provider, buffer, size);
-
-    if (!sfti)
-    {
-        SetLastError(ERROR_OUTOFMEMORY);
-        return 0;
-    }
-
-    sfti->ProviderSignature = provider;
-    sfti->Action = SystemFirmwareTable_Get;
-
-    status = NtQuerySystemInformation(SystemFirmwareTableInformation, sfti, buffer_size, &buffer_size);
-    buffer_size -= FIELD_OFFSET(SYSTEM_FIRMWARE_TABLE_INFORMATION, TableBuffer);
-    if (buffer_size <= size)
-        memcpy(buffer, sfti->TableBuffer, buffer_size);
-
-    if (status) SetLastError(RtlNtStatusToDosError(status));
-    HeapFree(GetProcessHeap(), 0, sfti);
-    return buffer_size;
+    FIXME("stub, always returning 0\n");
+    return 0;
 }

--- a/dlls/kernel32/cpu.c
+++ b/dlls/kernel32/cpu.c
@@ -369,8 +369,6 @@ UINT WINAPI GetSystemFirmwareTable(DWORD provider, DWORD id, void *buffer, DWORD
 
 /***********************************************************************
  *              EnumSystemFirmwareTables   (KERNEL32.@)
- *
- * See EnumSystemCodePagesA.
  */
 UINT WINAPI EnumSystemFirmwareTables(DWORD provider, void *buffer, DWORD size)
 {

--- a/dlls/kernel32/cpu.c
+++ b/dlls/kernel32/cpu.c
@@ -378,7 +378,7 @@ UINT WINAPI EnumSystemFirmwareTables(DWORD provider, void *buffer, DWORD size)
     SYSTEM_FIRMWARE_TABLE_INFORMATION *sfti = HeapAlloc(GetProcessHeap(), 0, buffer_size);
     NTSTATUS status;
 
-    FIXME("(0x%08x, %p, %d)\n", provider, buffer, size);
+    TRACE("(0x%08x, %p, %d)\n", provider, buffer, size);
 
     if (!sfti)
     {

--- a/dlls/kernel32/kernel32.spec
+++ b/dlls/kernel32/kernel32.spec
@@ -418,7 +418,7 @@
 @ stdcall EnumResourceTypesW(long ptr long)
 @ stdcall EnumSystemCodePagesA(ptr long)
 @ stdcall EnumSystemCodePagesW(ptr long)
-# @ stub EnumSystemFirmwareTables
+@ stdcall EnumSystemFirmwareTables(long ptr long)
 @ stdcall EnumSystemGeoID(long long ptr)
 @ stdcall EnumSystemLanguageGroupsA(ptr long ptr)
 @ stdcall EnumSystemLanguageGroupsW(ptr long ptr)

--- a/dlls/kernelbase/kernelbase.spec
+++ b/dlls/kernelbase/kernelbase.spec
@@ -312,7 +312,7 @@
 @ stdcall EnumResourceTypesExA(long ptr long long long)
 @ stdcall EnumResourceTypesExW(long ptr long long long)
 @ stdcall EnumSystemCodePagesW(ptr long) kernel32.EnumSystemCodePagesW
-# @ stub EnumSystemFirmwareTables
+@ stdcall EnumSystemFirmwareTables(long ptr long) kernel32.EnumSystemFirmwareTables
 @ stdcall EnumSystemGeoID(long long ptr) kernel32.EnumSystemGeoID
 @ stdcall EnumSystemLanguageGroupsW(ptr long ptr) kernel32.EnumSystemLanguageGroupsW
 @ stdcall EnumSystemLocalesA(ptr long) kernel32.EnumSystemLocalesA

--- a/dlls/ntdll/nt.c
+++ b/dlls/ntdll/nt.c
@@ -2540,7 +2540,7 @@ NTSTATUS WINAPI NtQuerySystemInformation(
                             /* ftCreationTime, ftUserTime, ftKernelTime;
                              * vmCounters, ioCounters
                              */
- 
+
                             memset(spi, 0, sizeof(*spi));
 
                             spi->NextEntryOffset = procstructlen - wlen;
@@ -2560,7 +2560,7 @@ NTSTATUS WINAPI NtQuerySystemInformation(
                     }
                 }
                 SERVER_END_REQ;
- 
+
                 if (ret != STATUS_SUCCESS)
                 {
                     if (ret == STATUS_NO_MORE_FILES) ret = STATUS_SUCCESS;
@@ -2919,7 +2919,7 @@ NTSTATUS WINAPI NtQuerySystemInformation(
 	FIXME("(0x%08x,%p,0x%08x,%p) stub\n",
 	      SystemInformationClass,SystemInformation,Length,ResultLength);
 
-        /* Several Information Classes are not implemented on Windows and return 2 different values 
+        /* Several Information Classes are not implemented on Windows and return 2 different values
          * STATUS_NOT_IMPLEMENTED or STATUS_INVALID_INFO_CLASS
          * in 95% of the cases it's STATUS_INVALID_INFO_CLASS, so use this as the default
         */

--- a/dlls/ntdll/nt.c
+++ b/dlls/ntdll/nt.c
@@ -2540,7 +2540,7 @@ NTSTATUS WINAPI NtQuerySystemInformation(
                             /* ftCreationTime, ftUserTime, ftKernelTime;
                              * vmCounters, ioCounters
                              */
-
+ 
                             memset(spi, 0, sizeof(*spi));
 
                             spi->NextEntryOffset = procstructlen - wlen;
@@ -2560,7 +2560,7 @@ NTSTATUS WINAPI NtQuerySystemInformation(
                     }
                 }
                 SERVER_END_REQ;
-
+ 
                 if (ret != STATUS_SUCCESS)
                 {
                     if (ret == STATUS_NO_MORE_FILES) ret = STATUS_SUCCESS;
@@ -2919,7 +2919,7 @@ NTSTATUS WINAPI NtQuerySystemInformation(
 	FIXME("(0x%08x,%p,0x%08x,%p) stub\n",
 	      SystemInformationClass,SystemInformation,Length,ResultLength);
 
-        /* Several Information Classes are not implemented on Windows and return 2 different values
+        /* Several Information Classes are not implemented on Windows and return 2 different values 
          * STATUS_NOT_IMPLEMENTED or STATUS_INVALID_INFO_CLASS
          * in 95% of the cases it's STATUS_INVALID_INFO_CLASS, so use this as the default
         */


### PR DESCRIPTION
A recent update to the game Everquest has caused it to always fail when run with wine. This is because it is calling the function `EnumSystemFirmewareTables`.

Adding a stub implementation that always returns zero solves the issue and allows the game to be fully functional.