### PR TITLE
aclocal.m4: fix compatibility with upcoming autoconf-2.70

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -28,7 +28,7 @@ dnl Like AC_CHECK_TOOL but without the broken fallback to non-prefixed name
 dnl
 AC_DEFUN([WINE_CHECK_HOST_TOOL],
 [AS_VAR_SET_IF([ac_tool_prefix],
-  AC_CHECK_PROG([$1],[${ac_tool_prefix}$2],[${ac_tool_prefix}$2],,[$4]))
+  [AC_CHECK_PROG([$1],[${ac_tool_prefix}$2],[${ac_tool_prefix}$2],,[$4])])
 AS_VAR_IF([ac_cv_prog_$1],[],
   [AS_VAR_IF([cross_compiling],[yes],[],
     [AS_UNSET([ac_cv_prog_$1])


### PR DESCRIPTION
Under autoconf 2.69c (beta) `./configure` fails as:

```
./configure
...
checking for msgfmt... msgfmt
./configure: line 7441: syntax error near unexpected token `newline'
./configure: line 7441: `    '''
```

This happens due to underquoting of a snippet
argument for `AS_VAR_SET_IF` call.

The change adds m4 quoting around it.

On `autoconf-2.69` there is no `./configure` code
generation change. On `autoconf-2.69c` `./configure`
gets to the finish.