### PR TITLE
msvcrt:msvcrt_get_flags: Fix bug 51846 - fopen(..., "wx")

### DIFF
--- a/dlls/msvcrt/file.c
+++ b/dlls/msvcrt/file.c
@@ -1586,6 +1586,9 @@ static int msvcrt_get_flags(const wchar_t* mode, int *open_flags, int* stream_fl
       *open_flags |=  _O_TEXT;
       *open_flags &= ~_O_BINARY;
       break;
+    case 'x':
+      *open_flags |= _O_EXCL;
+      break;
     case 'D':
       *open_flags |= _O_TEMPORARY;
       break;


### PR DESCRIPTION
This fixes [bug 51846](https://bugs.winehq.org/show_bug.cgi?id=51846): Standard library call `fopen(..., "wx")` not
recognized - causes destruction of data.

Signed-off-by: Ted Lyngmo <ted@lyncon.se>