### PR TITLE
More buffer in the titlebar

### DIFF
--- a/programs/winhlp32/hlpfile.h
+++ b/programs/winhlp32/hlpfile.h
@@ -26,7 +26,7 @@ typedef struct
 {
     char        type[10];
     char        name[9];
-    char        caption[51];
+    char        caption[300];
     POINT       origin;
     SIZE        size;
     int         style;


### PR DESCRIPTION
The buffer in the titlebar was small and the file path was truncated.
Therefore, the buffer in the titlebar was expanded from 51 to 300.