### PR TITLE
gdiplus: Reset the installedFontCollection.count field to zero upon release.

### DIFF
--- a/dlls/gdiplus/font.c
+++ b/dlls/gdiplus/font.c
@@ -1565,6 +1565,7 @@ void free_installed_fonts(void)
 
     installedFontCollection.FontFamilies = NULL;
     installedFontCollection.allocated = 0;
+    installedFontCollection.count = 0;
 }
 
 static INT CALLBACK add_font_proc(const LOGFONTW *lfw, const TEXTMETRICW *ntm,


### PR DESCRIPTION
The application crashes when attempting to load fonts internally, especially those with watermark functionalities. Reset the installedFontCollection.count field to zero upon release.