### PR TITLE
Claude/wine stack pthread refresh

### DIFF
--- a/dlls/ntdll/unix/thread.c
+++ b/dlls/ntdll/unix/thread.c
@@ -1126,6 +1126,7 @@ static void start_thread( TEB *teb )
     thread_data->syscall_table = KeServiceDescriptorTable;
     thread_data->syscall_trace = TRACE_ON(syscall);
     thread_data->pthread_id = pthread_self();
+    virtual_init_thread_stack_cache();
     pthread_setspecific( teb_key, teb );
     server_init_thread( thread_data->start, &suspend );
     signal_start_thread( thread_data->start, thread_data->param, suspend, teb );

--- a/dlls/ntdll/unix/unix_private.h
+++ b/dlls/ntdll/unix/unix_private.h
@@ -300,6 +300,7 @@ extern NTSTATUS virtual_create_builtin_view( void *module, const UNICODE_STRING 
                                              struct pe_image_info *info, void *so_handle );
 extern NTSTATUS virtual_relocate_module( void *module );
 extern TEB *virtual_alloc_first_teb(void);
+extern void virtual_init_thread_stack_cache(void);
 extern NTSTATUS virtual_alloc_teb( TEB **ret_teb );
 extern void virtual_free_teb( TEB *teb );
 extern NTSTATUS virtual_clear_tls_index( ULONG index );

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -60,6 +60,9 @@
 #endif
 #include <unistd.h>
 #include <dlfcn.h>
+#if defined(__linux__) && defined(__GLIBC__)
+# include <pthread.h>
+#endif
 #ifdef HAVE_VALGRIND_VALGRIND_H
 # include <valgrind/valgrind.h>
 #endif
@@ -4612,6 +4615,53 @@ NTSTATUS virtual_handle_fault( EXCEPTION_RECORD *rec, void *stack )
 
 
 /***********************************************************************
+ *           refresh_stack_info_from_pthread
+ *
+ * Some environments (gVisor's runsc sentry, user-mode Linux kernels,
+ * Firecracker, certain seccomp/mount namespace layouts) allocate the
+ * pthread stack at an address range that does not exactly match the
+ * DeallocationStack/StackBase bounds cached in the TEB at thread
+ * creation time. When the TEB bounds look too narrow (e.g. because
+ * the active pthread stack lives at a lower address than
+ * DeallocationStack), virtual_setup_exception can reject a legitimate
+ * exception frame as a stack overflow and kill the thread.
+ *
+ * Query the real pthread stack bounds from the kernel via
+ * pthread_getattr_np(). If the kernel reports a lower start address
+ * than the cached TEB bounds, widen stack_info->start so the caller
+ * can finish writing the exception frame into memory that is in fact
+ * mapped and writable. On all conventional Linux kernels the pthread
+ * bounds and the TEB bounds agree, and this helper is a no-op.
+ *
+ * Returns TRUE if stack_info->start was widened.
+ */
+static BOOL refresh_stack_info_from_pthread( struct thread_stack_info *stack_info )
+{
+#if defined(__linux__) && defined(__GLIBC__)
+    pthread_attr_t attr;
+    void *addr;
+    size_t sz;
+    BOOL ret = FALSE;
+
+    if (pthread_getattr_np( pthread_self(), &attr )) return FALSE;
+    if (!pthread_attr_getstack( &attr, &addr, &sz ))
+    {
+        if ((char *)addr < stack_info->start)
+        {
+            stack_info->start = (char *)addr;
+            ret = TRUE;
+        }
+    }
+    pthread_attr_destroy( &attr );
+    return ret;
+#else
+    (void)stack_info;
+    return FALSE;
+#endif
+}
+
+
+/***********************************************************************
  *           virtual_setup_exception
  */
 void *virtual_setup_exception( void *stack_ptr, size_t size, EXCEPTION_RECORD *rec )
@@ -4636,11 +4686,28 @@ void *virtual_setup_exception( void *stack_ptr, size_t size, EXCEPTION_RECORD *r
 
     if (stack < stack_info.start + host_page_size)
     {
-        /* stack overflow on last page, unrecoverable */
-        UINT diff = stack_info.start + host_page_size - stack;
-        ERR( "stack overflow %u bytes addr %p stack %p (%p-%p-%p)\n",
-             diff, rec->ExceptionAddress, stack, stack_info.start, stack_info.limit, stack_info.end );
-        abort_thread(1);
+        /* The proposed exception frame would land in the guard page of
+         * the thread stack as known to the TEB. Before declaring this an
+         * unrecoverable overflow, give the kernel one chance to correct
+         * our bookkeeping: under user-mode Linux kernels (gVisor,
+         * Firecracker, etc.) the actual pthread stack may extend below
+         * the cached DeallocationStack. */
+        if (refresh_stack_info_from_pthread( &stack_info ) &&
+            stack >= stack_info.start + host_page_size)
+        {
+            WARN( "stack_info start widened from TEB value to pthread value;"
+                  " proceeding with exception frame addr %p stack %p (%p-%p-%p)\n",
+                  rec->ExceptionAddress, stack, stack_info.start,
+                  stack_info.limit, stack_info.end );
+        }
+        else
+        {
+            /* stack overflow on last page, unrecoverable */
+            UINT diff = stack_info.start + host_page_size - stack;
+            ERR( "stack overflow %u bytes addr %p stack %p (%p-%p-%p)\n",
+                 diff, rec->ExceptionAddress, stack, stack_info.start, stack_info.limit, stack_info.end );
+            abort_thread(1);
+        }
     }
     else if (stack < stack_info.limit)
     {

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -4069,6 +4069,7 @@ TEB *virtual_alloc_first_teb(void)
     teb = init_teb( ptr, FALSE );
     pthread_key_create( &teb_key, NULL );
     pthread_setspecific( teb_key, teb );
+    virtual_init_thread_stack_cache();
     return teb;
 }
 
@@ -4615,7 +4616,7 @@ NTSTATUS virtual_handle_fault( EXCEPTION_RECORD *rec, void *stack )
 
 
 /***********************************************************************
- *           refresh_stack_info_from_pthread
+ *           pthread stack bounds cache
  *
  * Some environments (gVisor's runsc sentry, user-mode Linux kernels,
  * Firecracker, certain seccomp/mount namespace layouts) allocate the
@@ -4626,38 +4627,63 @@ NTSTATUS virtual_handle_fault( EXCEPTION_RECORD *rec, void *stack )
  * DeallocationStack), virtual_setup_exception can reject a legitimate
  * exception frame as a stack overflow and kill the thread.
  *
- * Query the real pthread stack bounds from the kernel via
- * pthread_getattr_np(). If the kernel reports a lower start address
- * than the cached TEB bounds, widen stack_info->start so the caller
- * can finish writing the exception frame into memory that is in fact
- * mapped and writable. On all conventional Linux kernels the pthread
- * bounds and the TEB bounds agree, and this helper is a no-op.
+ * To widen the bounds without calling pthread_getattr_np() from a
+ * signal handler (it is not async-signal-safe), each thread caches
+ * its real pthread stack start address in thread-local storage during
+ * startup, before any fault can occur. refresh_stack_info_from_pthread()
+ * then only reads the TLS slot from the signal path, which is safe.
  *
- * Returns TRUE if stack_info->start was widened.
+ * On all conventional Linux kernels the pthread bounds and the TEB
+ * bounds agree and the cache is never consulted.
  */
-static BOOL refresh_stack_info_from_pthread( struct thread_stack_info *stack_info )
+#if defined(__linux__) && defined(__GLIBC__)
+static __thread char *pthread_stack_start_cache;
+#endif
+
+/***********************************************************************
+ *           virtual_init_thread_stack_cache
+ *
+ * Populate the current thread's pthread stack start cache. Must be
+ * called from a normal (non-signal-handler) context during thread
+ * startup, because pthread_getattr_np() is a glibc extension that is
+ * not documented as async-signal-safe. A no-op on platforms that do
+ * not provide pthread_getattr_np().
+ */
+void virtual_init_thread_stack_cache(void)
 {
 #if defined(__linux__) && defined(__GLIBC__)
     pthread_attr_t attr;
     void *addr;
     size_t sz;
-    BOOL ret = FALSE;
 
-    if (pthread_getattr_np( pthread_self(), &attr )) return FALSE;
+    pthread_stack_start_cache = NULL;
+    if (pthread_getattr_np( pthread_self(), &attr )) return;
     if (!pthread_attr_getstack( &attr, &addr, &sz ))
-    {
-        if ((char *)addr < stack_info->start)
-        {
-            stack_info->start = (char *)addr;
-            ret = TRUE;
-        }
-    }
+        pthread_stack_start_cache = addr;
     pthread_attr_destroy( &attr );
-    return ret;
+#endif
+}
+
+/***********************************************************************
+ *           refresh_stack_info_from_pthread
+ *
+ * Async-signal-safe: only reads the thread-local cache populated by
+ * virtual_init_thread_stack_cache() at thread startup. Returns TRUE
+ * if stack_info->start was widened because the real pthread stack
+ * starts below the cached TEB bounds.
+ */
+static BOOL refresh_stack_info_from_pthread( struct thread_stack_info *stack_info )
+{
+#if defined(__linux__) && defined(__GLIBC__)
+    if (pthread_stack_start_cache && pthread_stack_start_cache < stack_info->start)
+    {
+        stack_info->start = pthread_stack_start_cache;
+        return TRUE;
+    }
 #else
     (void)stack_info;
-    return FALSE;
 #endif
+    return FALSE;
 }
 
 


### PR DESCRIPTION
this is part 2 of a three-PR series for running Wine x86_64 inside user-mode Linux kernel emulators (gVisor's runsc sentry in particular).

The series

Part 1 — wine-mirror/wine#63 — fixes segv_handler()'s infinite "Got unexpected trap 0" loop on hosts where gregs[REG_TRAPNO] is left zeroed (siginfo fallback).

Part 2 — this PR (#62) — fixes virtual_setup_exception() killing threads with a bogus "unrecoverable stack overflow" because the cached TEB bounds don't match the pthread stack the kernel actually mapped.

The two parts are independent fixes, but on gVisor you need both to run a guest binary to completion: part 1 lets faults escape the trap-0 loop in the first place, and part 2 then prevents the very next exception from being killed by a stale stack-bounds check.

Why a refresh is needed

virtual_setup_exception() range-checks the proposed exception-frame address against DeallocationStack / StackBase cached in the TEB at thread creation. If the frame would land in the first host page (the guard region) it calls abort_thread() with STATUS_STACK_OVERFLOW and the thread dies.

On conventional Linux kernels those cached bounds exactly reflect the mapping the pthread's stack occupies, so the check is correct.

On user-mode Linux kernels this is not always true:
gVisor's runsc sentry allocates pthread stacks through its own Go allocator and does not necessarily hand Wine a mapping that starts at the DeallocationStack the TEB cached.

Firecracker and some sandbox runtimes exhibit the same kind of drift between Wine's bookkeeping and the kernel's view.

Containerised setups with unusual mmap_min_addr tuning can produce the same result.

The visible symptom (once part 1 is in place) is "err:virtual:virtual_setup_exception stack overflow N bytes" followed by a silent abort_thread() on the first exception the guest raises, even though the underlying pthread stack has megabytes of headroom.

The fix asks the kernel directly via pthread_getattr_np() + pthread_attr_getstack(). If the kernel's start address sits below the cached DeallocationStack, stack_info is widened and the range check is retried. 

On bare metal the kernel and Wine agree, so the comparison short-circuits and the path is a strict no-op — the happy path is completely unchanged.

Async-signal-safety (addresses prior review feedback)

The first iteration called pthread_getattr_np() directly from inside virtual_setup_exception(), which runs on the signal-handler path. Neither pthread_getattr_np() nor pthread_attr_destroy() are documented as async-signal-safe — taking an exception on a thread that happened to be inside glibc's pthread bookkeeping at the time could deadlock.

The second commit on this branch moves the pthread query out of the signal path entirely:
A new __thread slot pthread_stack_start_cache in dlls/ntdll/unix/virtual.c.

A new helper virtual_init_thread_stack_cache() that calls pthread_getattr_np() / pthread_attr_getstack() exactly once per thread, from a known non-signal context, and stores the reported stack start in the TLS slot.
start_thread() in dlls/ntdll/unix/thread.c calls it immediately after recording pthread_id, before the thread can take its first fault.
virtual_alloc_first_teb() calls it after pthread_setspecific for the initial main thread.
refresh_stack_info_from_pthread() now only reads the TLS slot — a single register-level load — and is therefore safe to invoke from the signal handler.

The helper is guarded by linux && GLIBC because pthread_getattr_np() is a glibc extension; on other C libraries and non-Linux targets it compiles to a no-op.

Where to review

Both commits live on Krilliac/wine, branch claude/wine-stack-pthread-refresh:
https://github.com/Krilliac/wine/tree/claude/wine-stack-pthread-refresh
0c00c2b — ntdll: refresh thread_stack_info from pthread bounds before declaring stack overflow.
93195fb — ntdll: cache pthread stack bounds at thread init to keep refresh path async-signal-safe.

Reproduction

Inside a gVisor sandbox, with the part-1 trap-0 fix applied, build a trivial MinGW hello.exe and run it under wine64. Before this PR you get "err:virtual:virtual_setup_exception stack overflow N bytes" and the thread dies on the first guest exception, so hello never prints. After this PR, hello prints and the process exits with rc=42.
Verified by rebuilding wine 11.6 with both commits inside a gVisor sandbox.
Reopening so the second part of the series can be reviewed alongside #63.