### PR TITLE
wine wrgsbase fallback

### DIFF
--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -772,6 +772,37 @@ __ASM_GLOBAL_FUNC( clear_alignment_flag,
 
 
 /***********************************************************************
+ *           set_gs_base
+ *
+ * Set the gs.base MSR to point at the given TEB. Normally this is done
+ * via arch_prctl(ARCH_SET_GS), but some user-mode Linux kernel
+ * emulators (notably gVisor's runsc sentry) silently ignore
+ * arch_prctl(ARCH_SET_GS) calls: the syscall returns success but the
+ * write never takes effect, leaving gs.base at whatever the emulator
+ * initially chose (often a glibc-private address). Under those
+ * conditions Wine's PE ntdll hits NULL-pointer faults every time it
+ * reads NtCurrentTeb() via `%gs:0x30`.
+ *
+ * Use the wrgsbase instruction as the primary path - it modifies the
+ * gs.base MSR directly and works on every environment that exposes
+ * the fsgsbase feature to user mode, including gVisor. Verify by
+ * re-reading via a %gs-prefixed load (since rdgsbase can also be
+ * broken on emulators). Fall back to arch_prctl if wrgsbase had no
+ * effect, so that this helper is safe on hosts that disable
+ * CR4.FSGSBASE. If both paths fail, the caller sees a gs.base that
+ * still doesn't match teb and can escalate.
+ */
+static inline void set_gs_base( TEB *teb )
+{
+    ULONG_PTR probe = 0;
+    __asm__ volatile("wrgsbase %0" :: "r"((ULONG_PTR)teb));
+    __asm__ volatile("mov %%gs:0x30, %0" : "=r"(probe));
+    if (probe != (ULONG_PTR)teb)
+        arch_prctl( ARCH_SET_GS, teb );
+}
+
+
+/***********************************************************************
  *           init_handler
  */
 static inline ucontext_t *init_handler( void *sigcontext )
@@ -779,9 +810,24 @@ static inline ucontext_t *init_handler( void *sigcontext )
     clear_alignment_flag();
 #ifdef __linux__
     {
-        struct amd64_thread_data *thread_data = (struct amd64_thread_data *)&get_current_teb()->GdiTebBatch;
+        TEB *teb = get_current_teb();
+        struct amd64_thread_data *thread_data = (struct amd64_thread_data *)&teb->GdiTebBatch;
         thread_data->syscall_dispatch = 0; /* SYSCALL_DISPATCH_FILTER_ALLOW */
         if (fs32_sel) arch_prctl( ARCH_SET_FS, thread_data->pthread_teb );
+        /* Under gVisor's runsc sentry (and other user-mode Linux
+         * kernels), the initial arch_prctl(ARCH_SET_GS) call in
+         * signal_start_thread_c may have been silently ignored,
+         * leaving gs.base set to a non-TEB value. If the first fault
+         * on a thread is delivered via this handler while gs.base is
+         * still wrong, re-issue the set (via wrgsbase) here so the
+         * resumed user code sees the correct TEB via %gs:0x30. On
+         * bare-metal Linux arch_prctl works and this is a no-op. */
+        {
+            ULONG_PTR gs_self = 0;
+            __asm__ volatile("mov %%gs:0x30, %0" : "=r"(gs_self));
+            if (gs_self != (ULONG_PTR)teb)
+                set_gs_base( teb );
+        }
     }
 #elif defined __APPLE__
     {
@@ -2249,7 +2295,7 @@ static inline BOOL check_invalid_gsbase( ucontext_t *ucontext )
     TRACE( "gsbase %016lx teb %p at instr %p, fixing up\n", cur_gsbase, teb, instr );
 
 #ifdef __linux__
-    arch_prctl( ARCH_SET_GS, teb );
+    set_gs_base( teb );
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
     amd64_set_gsbase( teb );
 #elif defined(__NetBSD__)
@@ -2829,7 +2875,7 @@ void init_syscall_frame( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, 
     thread_data->instrumentation_callback = &instrumentation_callback;
 
 #if defined __linux__
-    arch_prctl( ARCH_SET_GS, teb );
+    set_gs_base( teb );
     if (fs32_sel)
     {
         arch_prctl( ARCH_GET_FS, &thread_data->pthread_teb );

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -794,11 +794,14 @@ __ASM_GLOBAL_FUNC( clear_alignment_flag,
  */
 static inline void set_gs_base( TEB *teb )
 {
-    ULONG_PTR probe = 0;
-    __asm__ volatile("wrgsbase %0" :: "r"((ULONG_PTR)teb));
-    __asm__ volatile("mov %%gs:0x30, %0" : "=r"(probe));
-    if (probe != (ULONG_PTR)teb)
-        arch_prctl( ARCH_SET_GS, teb );
+    if (user_shared_data->ProcessorFeatures[PF_RDWRFSGSBASE_AVAILABLE])
+    {
+        ULONG_PTR probe = 0;
+        __asm__ volatile("wrgsbase %0" :: "r"((ULONG_PTR)teb));
+        __asm__ volatile("mov %%gs:0x30, %0" : "=r"(probe));
+        if (probe == (ULONG_PTR)teb) return;
+    }
+    arch_prctl( ARCH_SET_GS, teb );
 }
 
 

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -774,34 +774,49 @@ __ASM_GLOBAL_FUNC( clear_alignment_flag,
 /***********************************************************************
  *           set_gs_base
  *
- * Set the gs.base MSR to point at the given TEB. Normally this is done
- * via arch_prctl(ARCH_SET_GS), but some user-mode Linux kernel
- * emulators (notably gVisor's runsc sentry) silently ignore
- * arch_prctl(ARCH_SET_GS) calls: the syscall returns success but the
- * write never takes effect, leaving gs.base at whatever the emulator
- * initially chose (often a glibc-private address). Under those
- * conditions Wine's PE ntdll hits NULL-pointer faults every time it
- * reads NtCurrentTeb() via `%gs:0x30`.
+ * Set the gs.base MSR to point at the given TEB.
  *
- * Use the wrgsbase instruction as the primary path - it modifies the
- * gs.base MSR directly and works on every environment that exposes
- * the fsgsbase feature to user mode, including gVisor. Verify by
- * re-reading via a %gs-prefixed load (since rdgsbase can also be
- * broken on emulators). Fall back to arch_prctl if wrgsbase had no
- * effect, so that this helper is safe on hosts that disable
- * CR4.FSGSBASE. If both paths fail, the caller sees a gs.base that
- * still doesn't match teb and can escalate.
+ * On bare-metal Linux, arch_prctl(ARCH_SET_GS) is the canonical path
+ * and always works. On user-mode Linux kernel emulators - notably
+ * gVisor's runsc sentry - arch_prctl(ARCH_SET_GS) either returns
+ * failure or lies (returns success but never writes the MSR), leaving
+ * gs.base at whatever the emulator initially chose (often a
+ * glibc-private address). Under those conditions Wine's PE ntdll hits
+ * NULL-pointer faults every time it reads NtCurrentTeb() via
+ * `%gs:0x30`.
+ *
+ * Try arch_prctl first and VERIFY the write took effect by reading
+ * `%gs:0x30` (which, on a correctly-initialised TEB, equals teb
+ * because teb->NtTib.Self is set to &teb->Tib and Tib is at offset 0
+ * inside TEB). If either the syscall failed or the verification
+ * mismatched, fall through to wrgsbase - a direct CPU instruction,
+ * not a syscall, that cannot be intercepted by an emulator.
+ *
+ * This layout keeps the pre-patch behaviour on every host that
+ * implements arch_prctl correctly, INCLUDING hosts that disable
+ * CR4.FSGSBASE. On those hosts arch_prctl works, verification
+ * passes, and the wrgsbase fallback is never executed, so there is
+ * no risk of an unconditional SIGILL from wrgsbase on a host where
+ * FSGSBASE is not enabled. The wrgsbase fallback is only reached
+ * when arch_prctl has already been proven broken, which in practice
+ * means a user-mode Linux kernel that does expose the FSGSBASE
+ * feature to user space (such as gVisor).
  */
 static inline void set_gs_base( TEB *teb )
 {
-    if (user_shared_data->ProcessorFeatures[PF_RDWRFSGSBASE_AVAILABLE])
+    ULONG_PTR probe = 0;
+
+    if (arch_prctl( ARCH_SET_GS, teb ) == 0)
     {
-        ULONG_PTR probe = 0;
-        __asm__ volatile("wrgsbase %0" :: "r"((ULONG_PTR)teb));
-        __asm__ volatile("mov %%gs:0x30, %0" : "=r"(probe));
+        __asm__ volatile( "movq %%gs:0x30, %0" : "=r"(probe) );
         if (probe == (ULONG_PTR)teb) return;
     }
-    arch_prctl( ARCH_SET_GS, teb );
+    /* arch_prctl failed or silently discarded the write - fall back
+     * to the wrgsbase instruction. This is only reached on broken
+     * hosts; on bare-metal Linux the early return above is always
+     * taken and wrgsbase is never executed, so hosts with
+     * CR4.FSGSBASE cleared are unaffected. */
+    __asm__ volatile( "wrgsbase %0" :: "r"((ULONG_PTR)teb) );
 }
 
 


### PR DESCRIPTION
This patch addresses a root-cause bug in Wine's x86_64 thread startup when running inside gVisor (runsc sentry) and other user-mode Linux kernel emulators.

The problem

Wine sets gs.base to point at the current thread's TEB via arch_prctl(ARCH_SET_GS, teb). 

On bare-metal Linux and conventional hypervisor VMs this works correctly.

On gVisor's runsc sentry it silently does nothing: the syscall returns 0 (success) but gs.base is never written, leaving it at whatever the Go runtime inside the sentry initially chose (typically a glibc-private address like 0x7ff7_3491_0000).

Every subsequent %gs:0x30 load in PE ntdll — the implementation of NtCurrentTeb() — then returns garbage.

The first casualty is loader_init(), which reads teb->Peb via %gs:0x30 and immediately begins dereferencing a non-TEB pointer.

Because gVisor's address layout happens to keep that region partially mapped, the early instructions succeed; the crash lands at the first NULL-derived pointer dereference. 

From there the exception dispatcher itself begins to spiral — __wine_dbg_get_channel_flags reads from a bogus debug_options pointer, each iteration pushes another exception frame, and virtual_setup_exception eventually kills the thread with a stack overflow.

Why wrgsbase

wrgsbase modifies gs.base via a direct CPU instruction — no syscall, no kernel involvement. 
An emulator that exposes the FSGSBASE feature to user mode (as gVisor does, because its host kernel has it) cannot silently swallow it the way it can an arch_prctl call. 

We verify the write landed by immediately reading back via mov %gs:0x30, %reg; if the probe value does not match teb we fall back to arch_prctl so the helper degrades gracefully.

The wrgsbase path is gated on user_shared_data->ProcessorFeatures[PF_RDWRFSGSBASE_AVAILABLE], which is exactly the same flag Wine already uses before rdgsbase in check_invalid_gsbase() (and in the syscall-dispatcher fast paths). 

On hosts where CR4.FSGSBASE is not set wrgsbase would raise #UD; the gate prevents that and falls straight through to arch_prctl, preserving identical behaviour to the pre-patch code.

Call sites updated

init_syscall_frame
Primary thread-start path; fixing this alone is sufficient to boot Wine correctly under gVisor
check_invalid_gsbase
Copy-protection workaround path; kept consistent
init_handler
Added a narrow fixup: if a signal arrives while %gs:0x30 ≠ teb (i.e. arch_prctl was silently dropped before the thread had a chance to call init_syscall_frame), re-issue set_gs_base(teb) on entry so resumed user code sees the correct TEB

Reproduction

# Inside a gVisor container (docker run --runtime=runsc ...)

cat > hello.c << 'EOF'
#include <stdio.h>
int main(void) { puts("hello"); return 42; }
EOF

x86_64-w64-mingw32-gcc hello.c -o hello.exe
wine64 hello.exe; echo rc=$?

Before this patch (with the companion trap-0 fix applied): Wine gets past the segv_handler loop but crashes in the loader with a stack overflow abort; hello never prints; rc=139.

After this patch: Wine runs hello.exe to completion, prints hello, exits rc=42.
Relation to companion patches
This patch is the third in a series of three gVisor compatibility fixes, all independent and applicable separately:
ntdll: fall back to siginfo for trap code when REG_TRAPNO is zero — fixes segv_handler looping on "Got unexpected trap 0" because gVisor leaves gregs[REG_TRAPNO] zeroed.

ntdll: refresh thread_stack_info from pthread bounds before declaring stack overflow — fixes a false "stack overflow" abort caused by gVisor's pthread stack start address not matching Wine's cached TEB bounds.

This patch — fixes the root cause that makes the loader crash entirely: 
arch_prctl(ARCH_SET_GS) being silently ignored.
Patches 1 and 2 are also available for review if there is interest. All three were developed against wine 11.6 and syntax-verified under -Wall -Wextra -Werror; this patch has been runtime-tested end-to-end on a gVisor container (see reproduction above).