### PR TITLE
dinput: Use the raw input interface for legacy keyboard devices as well.

### DIFF
--- a/dlls/dinput/keyboard.c
+++ b/dlls/dinput/keyboard.c
@@ -205,7 +205,7 @@ HRESULT keyboard_create_device( struct dinput *dinput, const GUID *guid, IDirect
     impl->base.caps.dwDevType = impl->base.instance.dwDevType;
     impl->base.caps.dwFirmwareRevision = 100;
     impl->base.caps.dwHardwareRevision = 100;
-    if (dinput->dwVersion >= 0x0800) impl->base.use_raw_input = TRUE;
+    impl->base.use_raw_input = TRUE;
     subtype = GET_DIDEVICE_SUBTYPE( impl->base.instance.dwDevType );
 
     if (FAILED(hr = dinput_device_init_device_format( &impl->base.IDirectInputDevice8W_iface ))) goto failed;


### PR DESCRIPTION
Legacy DirectInput (dwVersion < 0x0800) keyboard devices receive buffered events from the low-level keyboard hook installed on the dinput input thread. The hook is invoked while the corresponding hardware message is still being withheld from the application, so a game that polls GetDeviceData from its main loop can observe the buffered event one message-pump iteration before the WM_KEYDOWN for the same keystroke becomes retrievable.

Games that trigger GUI hotkeys from buffered DirectInput events while also processing keyboard messages for their GUI, such as Neverwinter Nights (2002), then double-activate: the DirectInput event opens a menu, and the same keystroke's message closes it again.

Routing legacy keyboard devices through the raw input path queues the hardware message together with the raw input instead of withholding it, restoring the ordering such games expect. Commit aa7a6b8f4284 (dinput: Use rawinput interface for keyboard device.) introduced the raw input path for dwVersion >= 0x0800 only, matching the behavior that test_mouse_keyboard() verifies on Windows for DirectInput 8; no test asserts that legacy devices avoid raw input registration. The legacy dinput.dll of current Windows versions also routes input through the modern InputHost pipeline rather than low-level hooks.

Exclusive-mode message suppression is unaffected, as it is handled via RIDEV_NOLEGACY.

Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=59962