### PR TITLE
ntdll/actctx‎: Don't dereference ActivateActCtx's cookie if it's just a nullptr

### DIFF
--- a/dlls/ntdll/actctx.c
+++ b/dlls/ntdll/actctx.c
@@ -5524,8 +5524,9 @@ NTSTATUS WINAPI RtlActivateActivationContextEx( ULONG flags, TEB *teb, ACTIVATIO
     actctx_stack->ActiveFrame = frame;
     RtlAddRefActivationContext( actctx );
 
-    *cookie = (ULONG_PTR)frame;
-    TRACE( "%p cookie=%Ix\n", actctx, *cookie );
+    if (cookie)
+        *cookie = (ULONG_PTR)frame;
+    TRACE( "%p cookie=%Ix\n", actctx, frame );
     return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
This is the Windows behavior since XP (before that the API didn't exist), if nullptr is passed as cookie, it just ignores it instead of dereferencing it.

Code to test:
```C
#include <windows.h>

LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
{
    switch (msg)
    {
    case WM_CREATE:
        CreateWindow(
            "BUTTON",
            "Click Me",
            WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
            50, 50,
            100, 30,
            hwnd,
            (HMENU)1,
            ((LPCREATESTRUCT)lParam)->hInstance,
            NULL);
        break;

    case WM_DESTROY:
        PostQuitMessage(0);
        break;
    }
    return DefWindowProc(hwnd, msg, wParam, lParam);
}

extern "C" IMAGE_DOS_HEADER __ImageBase;
#define hInst (reinterpret_cast<HMODULE>(&__ImageBase))

extern "C" [[noreturn]] void start();
void start()
{
    const char CLASS_NAME[] = "MinimalWindowClass";

    WNDCLASS wc = {0};
    wc.lpfnWndProc = WndProc;
    wc.hInstance = hInst;
    wc.lpszClassName = CLASS_NAME;
    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
    wc.hCursor = LoadCursor(NULL, IDC_ARROW);

    RegisterClass(&wc);

    {
        // Derived from https://stackoverflow.com/a/10444161
        char dir[MAX_PATH];
        GetSystemDirectoryA(dir, MAX_PATH);
        ACTCTXA actCtx = {0};
        actCtx.cbSize = sizeof(actCtx);
        actCtx.dwFlags = ACTCTX_FLAG_RESOURCE_NAME_VALID | ACTCTX_FLAG_SET_PROCESS_DEFAULT | ACTCTX_FLAG_ASSEMBLY_DIRECTORY_VALID;
        actCtx.lpSource = "shell32.dll";
        actCtx.lpAssemblyDirectory = dir;
        actCtx.lpResourceName = MAKEINTRESOURCEA(124);
        ActivateActCtx(CreateActCtxA(&actCtx), NULL);
    }

    HWND hwnd = CreateWindow(
        CLASS_NAME,
        "Win32 Minimal App",
        WS_OVERLAPPEDWINDOW,
        CW_USEDEFAULT, CW_USEDEFAULT,
        300, 200,
        NULL,
        NULL,
        hInst,
        NULL);

    ShowWindow(hwnd, 5);

    MSG msg = {0};
    while (GetMessage(&msg, NULL, 0, 0))
    {
        TranslateMessage(&msg);
        DispatchMessage(&msg);
    }

    ExitProcess(0);
}
```

The following code works in XP.

<img width="317" height="225" alt="image" src="https://github.com/user-attachments/assets/d4439213-a17f-42dd-8077-2d078265cfee" />

But crashes in Wine,

<img width="423" height="324" alt="image" src="https://github.com/user-attachments/assets/8b087861-108b-44ac-a949-34a994a5d615" />

If you remove `ActivateActCtx(CreateActCtxA(&actCtx), NULL);`  visual styles will be disabled in XP

<img width="323" height="228" alt="image" src="https://github.com/user-attachments/assets/80367b0d-a2fe-4d0a-afea-9439c2d13a06" />

Showing this line was indeed working in XP.

And if you turn `ActivateActCtx(CreateActCtxA(&actCtx), NULL);` to `ULONG_PTR cookie; ActivateActCtx(CreateActCtxA(&actCtx), &cookie);` it makes it works in Wine

<img width="326" height="220" alt="image" src="https://github.com/user-attachments/assets/be18014c-9c86-47a6-a3dc-82a9cc6a6213" />

showing this indeed was failing because of passing nullptr.
